### PR TITLE
path resolution plus default port

### DIFF
--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -14,7 +14,7 @@ import path from 'path';
 import { handleSquirrelEvent } from './handle-squirrel-event';
 
 const isDev = process.env.ENV === 'dev';
-const url = isDev ? 'http://localhost/comm/' : 'https://web.comm.app';
+const url = isDev ? 'http://localhost:3000/comm/' : 'https://web.comm.app';
 const isMac = process.platform === 'darwin';
 
 const scrollbarCSS = fs.promises.readFile(

--- a/keyserver/loader.mjs
+++ b/keyserver/loader.mjs
@@ -15,7 +15,7 @@ async function resolve(specifier, context, nextResolve) {
       continue;
     }
     const path = localPackages[pkg];
-    const url = defaultResult.url.replace(path, `keyserver/dist/${pkg}`);
+    const url = defaultResult.url.replace(`comm/${path}`, `comm/keyserver/dist/${pkg}`);
     return { url };
   }
 


### PR DESCRIPTION
# Introduction
This PR includes the following two fixings:

- path resolution
- default port
# Details
1. Path resolution
I'd got a scenario where 
it was replacing a similar directory in the path instead of the target pkg: 
e.g.
 file:///Users/XXXX/`web`3Service/comm/web/media/file-utils.js  was getting resolved into file:///Users/XXXX/`keyserver/dist/web`3Service/comm/web/media/file-utils.js where `pkg = 'web'`
 
 2. added default port 3000 in `desktop/src/main.js`