### PR TITLE
Fix: Message tooltip was rendered in an old position [web]

### DIFF
--- a/web/utils/tooltip-action-utils.js
+++ b/web/utils/tooltip-action-utils.js
@@ -405,7 +405,7 @@ function useMessageTooltip({
       setTooltipMessagePosition(messagePosition);
 
       const tooltipResult = createTooltip({
-        tooltipMessagePosition,
+        tooltipMessagePosition: messagePosition,
         tooltipSize,
         availablePositions,
         containsInlineEngagement,
@@ -437,7 +437,6 @@ function useMessageTooltip({
       renderTooltip,
       threadInfo,
       tooltipActions,
-      tooltipMessagePosition,
       tooltipSize,
     ],
   );


### PR DESCRIPTION
### Description:
This PR contains a small fix for an issue with web tooltip, that was rendered in incorrect position, when the screen was scrolled before opening it. In particular, after entering mouse over the message for the first time, the tooltip was not opening at all.

The source of the issue was introduced probably in [this commit](https://github.com/CommE2E/comm/commit/9a56f3635370177977ee8bbf955ce3dffcfaf43e#diff-bc183eda4c0b53325f97c9810077c55e0c2eccfe894a2a9427f24eae2801a543R568-R571) (cc: @palys-swm). Originally (almost a year ago when I created that logic) in `onMouseEnter` handler, `findTooltipPosition` was called with message position calculated directly from `getBoundingClientRect`, but after the problem was introduced, it was called with position kept in the state, that was not updated until the next render.


### Resources:
Videos demonstrating the tooltip behavior before and after the fix:

**Before**:

https://github.com/CommE2E/comm/assets/25308982/06a59f25-2e37-410b-a5cf-77f131edbec7

**After**:

https://github.com/CommE2E/comm/assets/25308982/b20533a9-d761-44f4-a2a5-2c9c190ceab9
